### PR TITLE
add ChannelClosed clauses for newly seen failure-cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 - 2021-02-01
+
+### Fixed
+
+- Connection now correctly emits ChannelClosed events for `:gun` events which
+  occur when a service's network access is terminated
+
 ## 0.2.0 - 2021-02-01
 
 ### Added

--- a/lib/slipstream/connection.ex
+++ b/lib/slipstream/connection.ex
@@ -68,6 +68,14 @@ defmodule Slipstream.Connection do
   end
 
   def handle_info(
+        {:gun_error, conn, {:websocket, stream_ref, _, _, _},
+         {:closed, 'The connection was lost.'}},
+        %State{conn: conn, stream_ref: stream_ref} = state
+      ) do
+    emit_channel_closed(:connection_lost, state)
+  end
+
+  def handle_info(
         {:gun_ws, conn, stream_ref, {:close, _, _}},
         %State{conn: conn, stream_ref: stream_ref} = state
       ) do

--- a/lib/slipstream/connection.ex
+++ b/lib/slipstream/connection.ex
@@ -61,17 +61,17 @@ defmodule Slipstream.Connection do
   end
 
   def handle_info(
-        {:gun_down, conn, :ws, :closed, [], []},
+        {:gun_down, conn, :ws, :closed, _refs, []},
         %State{conn: conn} = state
       ) do
-    emit_channel_closed(:closed_by_remote)
+    emit_channel_closed(:closed_by_remote, state)
   end
 
   def handle_info(
         {:gun_ws, conn, stream_ref, {:close, _, _}},
         %State{conn: conn, stream_ref: stream_ref} = state
       ) do
-    emit_channel_closed(:closed_by_remote)
+    emit_channel_closed(:closed_by_remote, state)
   end
 
   # coveralls-ignore-start
@@ -141,7 +141,7 @@ defmodule Slipstream.Connection do
     |> Impl.handle_command(cmd)
   end
 
-  defp emit_channel_closed(reason) do
+  defp emit_channel_closed(reason, state) do
     event = %Events.ChannelClosed{reason: reason}
 
     # if we're already terminating, no need to duplicate the channel_closed

--- a/test/slipstream/connection_test.exs
+++ b/test/slipstream/connection_test.exs
@@ -129,6 +129,27 @@ defmodule Slipstream.ConnectionTest do
       refute c.socket |> await_disconnect!() |> connected?
     end
 
+    # e.g. your networking interface shuts down
+    test """
+         when the remote websocket connection is lost,
+         then the socket is notified that the connection has been terminated
+         and the connection is closed
+         """,
+         c do
+      conn = c.conn
+
+      @gun |> expect(:close, 1, fn ^conn -> :ok end)
+
+      send(
+        c.socket.channel_pid,
+        {:gun_error, c.conn,
+         {:websocket, c.stream_ref, "VFeeglQh/qqSFe9rqSM5FQ==", [], %{}},
+         {:closed, 'The connection was lost.'}}
+      )
+
+      refute c.socket |> await_disconnect!() |> connected?
+    end
+
     test "when the connection receives a ping, then it responds with pong", c do
       conn = c.conn
 


### PR DESCRIPTION
saw these from an Istio shutdown of a service using slipstream

gotta catch'em all

closes #7 
closes #8