### PR TITLE
implement disconnection on heartbeat-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 - 2021-02-01
+
+### Fixed
+
+- The connection now properly disconnects when the server's heartbeat replies
+  timeout with requests
+    - disconnects for this reason will send have `:heartbeat_timeout` as the
+      reason referenced in `c:Slipstream.handle_disconnect/2`
+
 ## 0.2.1 - 2021-02-01
 
 ### Fixed

--- a/lib/slipstream/connection/state.ex
+++ b/lib/slipstream/connection/state.ex
@@ -79,10 +79,21 @@ defmodule Slipstream.Connection.State do
   @spec apply_command(%__MODULE__{}, command :: struct()) :: %__MODULE__{}
   def apply_command(state, command)
 
-  def apply_command(%__MODULE__{} = state, %Commands.SendHeartbeat{}) do
+  def apply_command(
+        %__MODULE__{heartbeat_ref: nil} = state,
+        %Commands.SendHeartbeat{}
+      ) do
     {ref, state} = next_ref(state)
 
     %__MODULE__{state | heartbeat_ref: ref}
+  end
+
+  def apply_command(
+        %__MODULE__{heartbeat_ref: existing_heartbeat_ref} = state,
+        %Commands.SendHeartbeat{}
+      )
+      when is_binary(existing_heartbeat_ref) do
+    %__MODULE__{state | heartbeat_ref: :error}
   end
 
   def apply_command(%__MODULE__{} = state, %Commands.PushMessage{}) do

--- a/test/slipstream/connection_test.exs
+++ b/test/slipstream/connection_test.exs
@@ -179,4 +179,69 @@ defmodule Slipstream.ConnectionTest do
       refute c.socket |> await_disconnect!() |> connected?
     end
   end
+
+  describe "given an open connection socket with heartbeat interval set very low" do
+    setup c do
+      conn = self()
+      stream_ref = make_ref()
+
+      @gun
+      |> stub(:open, fn _host, _port, _opts ->
+        # N.B.: we're providing the test process as the conn so it makes life
+        # easier later when we expect messages and want to send them to the
+        # test process for an assert_receive/2
+        {:ok, conn}
+      end)
+      |> stub(:ws_upgrade, fn _conn, _path, _headers, _opts ->
+        send(
+          self(),
+          {:gun_upgrade, conn, stream_ref, ["websocket"], _headers = []}
+        )
+
+        stream_ref
+      end)
+
+      config =
+        c.config
+        # 20ms between heartbeat requests
+        |> Keyword.put(:heartbeat_interval_msec, 20)
+
+      [config: config, conn: conn, stream_ref: stream_ref]
+    end
+
+    test """
+         when we snub heartbeat responses to the connection process,
+         then the client will disconnect
+         """,
+         c do
+      conn = c.conn
+
+      @gun
+      |> expect(:ws_send, 1, fn ^conn, {:text, heartbeat_request} ->
+        request =
+          heartbeat_request
+          |> IO.iodata_to_binary()
+          |> Jason.decode!()
+
+        send(conn, {:request, request})
+
+        :ok
+      end)
+      |> expect(:close, 1, fn ^conn -> :ok end)
+
+      socket = c.config |> connect!() |> await_connect!()
+
+      assert connected?(socket)
+
+      assert_receive {:request,
+                      [_join_ref, _ref, "phoenix", "heartbeat", _payload]}
+
+      # we don't send the connection process a reply to that heartbeat, so we
+      # expect it to disconnect the client
+
+      assert {:ok, socket} = await_disconnect(socket)
+
+      assert connected?(socket) == false
+    end
+  end
 end

--- a/test/slipstream/connection_test.exs
+++ b/test/slipstream/connection_test.exs
@@ -15,7 +15,7 @@ defmodule Slipstream.ConnectionTest do
   import Slipstream
   import Slipstream.Socket, except: [send: 2]
   import Slipstream.Signatures
-  alias Slipstream.{Commands}
+  alias Slipstream.{Commands, Events}
 
   import Mox
   setup :verify_on_exit!
@@ -239,9 +239,13 @@ defmodule Slipstream.ConnectionTest do
       # we don't send the connection process a reply to that heartbeat, so we
       # expect it to disconnect the client
 
-      assert {:ok, socket} = await_disconnect(socket)
+      # also, normally we would test the disconnect with this code:
+      #     assert {:ok, socket} = await_disconnect(socket)
+      #     assert connected?(socket) == false
+      # which passes the test, but I want to get that disconnect reason
+      # and assert that it is :heartbeat_timeout
 
-      assert connected?(socket) == false
+      assert_receive event(%Events.ChannelClosed{reason: :heartbeat_timeout})
     end
   end
 end


### PR DESCRIPTION
I had this as a yard at some point but I must've forgotten about it

when the server stops sending us replies to our heartbeat requests, we should close the connection with reason `:heartbeat_timeout`