### PR TITLE
remove dependency on phoenix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2021-02-24
+
+### Removed
+
+- Removed dependency on Phoenix
+
 ## 0.5.4 - 2021-02-22
 
 ### Fixed

--- a/lib/slipstream/connection/impl.ex
+++ b/lib/slipstream/connection/impl.ex
@@ -7,7 +7,7 @@ defmodule Slipstream.Connection.Impl do
   @moduledoc false
 
   alias Slipstream.Connection.State
-  alias Phoenix.Socket.Message
+  alias Slipstream.Message
   import Slipstream.Signatures, only: [event: 1]
 
   # in test mode, we want to be able to swap out `:gun` for a mock

--- a/lib/slipstream/connection/pipeline.ex
+++ b/lib/slipstream/connection/pipeline.ex
@@ -5,8 +5,7 @@ defmodule Slipstream.Connection.Pipeline do
   import Slipstream.Signatures
   import Slipstream.Connection.Impl, only: [gun: 0, route_event: 2]
   alias Slipstream.Connection.{Impl, State, Telemetry}
-  alias Slipstream.{Commands, Events}
-  alias Phoenix.Socket.Message
+  alias Slipstream.{Commands, Events, Message}
 
   require Logger
 

--- a/lib/slipstream/events.ex
+++ b/lib/slipstream/events.ex
@@ -3,7 +3,7 @@ defmodule Slipstream.Events do
 
   require Logger
 
-  alias Phoenix.Socket.Message
+  alias Slipstream.Message
 
   alias __MODULE__.{
     MessageReceived,
@@ -29,7 +29,7 @@ defmodule Slipstream.Events do
   information about the `ref` fields on messages and whether or not they belong
   to joins or leaves.
 
-  `server_message` is either a `%Phoenix.Socket.Message{}` or `:ping` or `:pong`.
+  `server_message` is either a `%Slipstream.Message{}` or `:ping` or `:pong`.
   `connection_state` is the GenServer state of the connection process.
   """
   @spec map(atom() | %Message{}, %State{}) :: struct()

--- a/lib/slipstream/message.ex
+++ b/lib/slipstream/message.ex
@@ -1,0 +1,27 @@
+defmodule Slipstream.Message do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          topic: String.t(),
+          event: String.t(),
+          payload: term(),
+          ref: String.t() | nil,
+          join_ref: String.t() | nil
+        }
+
+  defstruct ~w[topic event payload ref join_ref]a
+
+  # a wrapper around Phoenix.Socket.Message
+  # represents a message sent from the remote websocket server
+
+  @spec from_map!(%{String.t() => term()}) :: t()
+  def from_map!(map) when is_map(map) do
+    %__MODULE__{
+      topic: Map.fetch!(map, "topic"),
+      event: Map.fetch!(map, "event"),
+      payload: Map.fetch!(map, "payload"),
+      ref: Map.fetch!(map, "ref"),
+      join_ref: Map.get(map, "join_ref")
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,6 @@ defmodule Slipstream.MixProject do
   defp deps do
     [
       {:gun, "~> 1.0"},
-      {:phoenix, "~> 1.0"},
       {:telemetry, "~> 0.4"},
       {:jason, "~> 1.0", optional: true},
       {:nimble_options, "~> 0.1"},
@@ -67,6 +66,7 @@ defmodule Slipstream.MixProject do
       {:ex_doc, ">= 0.0.0", only: [:docs], runtime: false},
       {:inch_ex, "== 2.1.0-rc.1", only: [:docs]},
       # test
+      {:phoenix, "~> 1.0", only: [:dev, :test, :docs]},
       {:cowlib, "~> 2.9", override: true, only: [:dev, :test]},
       {:phoenix_pubsub, "~> 2.0", override: true, only: [:docs, :dev, :test]},
       {:plug_cowboy, "~> 2.0", only: [:dev, :test]},

--- a/test/slipstream/message_test.exs
+++ b/test/slipstream/message_test.exs
@@ -6,10 +6,10 @@ defmodule Slipstream.MessageTest do
   test "from_map!/1 raises a KeyError on a malformed message" do
     # malformed because there is no payload key
     malformed_message = %{
-      topic: "rooms:lobby",
-      event: "msg:new",
-      ref: nil,
-      join_ref: nil
+      "topic" => "rooms:lobby",
+      "event" => "msg:new",
+      "ref" => nil,
+      "join_ref" => nil
     }
 
     assert_raise KeyError, fn -> Message.from_map!(malformed_message) end

--- a/test/slipstream/message_test.exs
+++ b/test/slipstream/message_test.exs
@@ -1,0 +1,17 @@
+defmodule Slipstream.MessageTest do
+  use ExUnit.Case, async: true
+
+  alias Slipstream.Message
+
+  test "from_map!/1 raises a KeyError on a malformed message" do
+    # malformed because there is no payload key
+    malformed_message = %{
+      topic: "rooms:lobby",
+      event: "msg:new",
+      ref: nil,
+      join_ref: nil
+    }
+
+    assert_raise KeyError, fn -> Message.from_map!(malformed_message) end
+  end
+end


### PR DESCRIPTION
closes #26 

didn't really need phoenix for very much, just that `Phoenix.Socket.Message` struct which is pretty slim

here's the implementation upstream: https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/socket/message.ex