### PR TITLE
handle unmatched return dialyzer errors

### DIFF
--- a/lib/slipstream.ex
+++ b/lib/slipstream.ex
@@ -1491,7 +1491,7 @@ defmodule Slipstream do
           ) do
         socket = TelemetryHelper.begin_connect(socket, cmd.config)
 
-        Slipstream.CommandRouter.route_command(cmd)
+        _ = Slipstream.CommandRouter.route_command(cmd)
 
         {:noreply, socket}
       end
@@ -1504,7 +1504,7 @@ defmodule Slipstream do
           ) do
         socket = TelemetryHelper.begin_join(socket, cmd.topic, cmd.payload)
 
-        Slipstream.CommandRouter.route_command(cmd)
+        _ = Slipstream.CommandRouter.route_command(cmd)
 
         {:noreply, socket}
       end


### PR DESCRIPTION
Dialyzer fails with `unmatched_return` errors in my apps using slipstream. I happen to use that everywhere, so this is prob more of a convenience for me, but dialyzer passes after this.

<details>
<summary>Dialyzer log</summary>

```
jonjon@bender:~/repos/nerves_hub_link$ mix dialyzer
Compiling 11 files (.ex)
Generated nerves_hub_link app
Finding suitable PLTs
Checking PLT...
[:asn1, :atecc508a, :castore, :certifi, :compiler, :cowlib, :crypto, :elixir, :extty, :fwup, :gun, :hackney, :idna, :iex, :inets, :jason, :kernel, :logger, :metrics, :mimerl, :mint, :nerves_hub_link_common, :nerves_key, :nerves_key_pkcs11, :nerves_runtime, :nimble_options, :parse_trans, :public_key, :slipstream, :ssl, :ssl_verify_fun, :stdlib, :syntax_tools, :system_registry, :telemetry, :uboot_env, :unicode_util_compat, :x509]
Looking up modules in dialyxir_erlang-23.2.5_elixir-1.11.3_deps-dev.plt
Finding applications for dialyxir_erlang-23.2.5_elixir-1.11.3_deps-dev.plt
Finding modules for dialyxir_erlang-23.2.5_elixir-1.11.3_deps-dev.plt
Checking 932 modules in dialyxir_erlang-23.2.5_elixir-1.11.3_deps-dev.plt
Adding 42 modules to dialyxir_erlang-23.2.5_elixir-1.11.3_deps-dev.plt
done in 0m4.44s
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: '/home/jonjon/repos/nerves_hub_link/_build/dev/dialyxir_erlang-23.2.5_elixir-1.11.3_deps-dev.plt',
  files: ['/home/jonjon/repos/nerves_hub_link/_build/dev/lib/nerves_hub_link/ebin/Elixir.NervesHubLink.Application.beam',
   '/home/jonjon/repos/nerves_hub_link/_build/dev/lib/nerves_hub_link/ebin/Elixir.NervesHubLink.Certificate.beam',
   '/home/jonjon/repos/nerves_hub_link/_build/dev/lib/nerves_hub_link/ebin/Elixir.NervesHubLink.Client.Default.beam',
   '/home/jonjon/repos/nerves_hub_link/_build/dev/lib/nerves_hub_link/ebin/Elixir.NervesHubLink.Client.beam',
   '/home/jonjon/repos/nerves_hub_link/_build/dev/lib/nerves_hub_link/ebin/Elixir.NervesHubLink.Configurator.Config.beam',
   ...],
  warnings: [:race_conditions, :error_handling, :underspecs, :unmatched_returns,
   ...]
]
Total errors: 2, Skipped: 0, Unnecessary Skips: 0
done in 0m1.57s
lib/slipstream.ex:1494:unmatched_return
The expression produces a value of type:


  :ignore
  | :ok
  | {:error, _}
  | {:ok, _}
  | {:ok, pid(), _}
  | %Slipstream.Socket{
      :assigns => map(),
      :channel_config =>
        nil
        | %Slipstream.Configuration{
            :gun_open_options => _,
            :headers => [{_, _}],
            :heartbeat_interval_msec => non_neg_integer(),
            :json_parser => atom(),
            :reconnect_after_msec => [non_neg_integer()],
            :rejoin_after_msec => [non_neg_integer()],
            :test_mode? => _,
            :uri => %URI{
              :authority => _,
              :fragment => _,
              :host => _,
              :path => _,
              :port => _,
              :query => _,
              :scheme => _,
              :userinfo => _
            }
          },
      :channel_pid => nil | pid(),
      :joins => %{
        binary() => %Slipstream.Socket.Join{
          :params => _,
          :rejoin_counter => _,
          :status => _,
          :topic => _
        }
      },
      :metadata => %{atom() => binary() | %{binary() => binary()}},
      :reconnect_counter => non_neg_integer(),
      :response_headers => _,
      :socket_pid => pid()
    }


but this value is unmatched.

________________________________________________________________________________
lib/slipstream.ex:1507:unmatched_return
The expression produces a value of type:


  :ignore
  | :ok
  | {:error, _}
  | {:ok, _}
  | {:ok, pid(), _}
  | %Slipstream.Socket{
      :assigns => map(),
      :channel_config =>
        nil
        | %Slipstream.Configuration{
            :gun_open_options => _,
            :headers => [{_, _}],
            :heartbeat_interval_msec => non_neg_integer(),
            :json_parser => atom(),
            :reconnect_after_msec => [non_neg_integer()],
            :rejoin_after_msec => [non_neg_integer()],
            :test_mode? => _,
            :uri => %URI{
              :authority => _,
              :fragment => _,
              :host => _,
              :path => _,
              :port => _,
              :query => _,
              :scheme => _,
              :userinfo => _
            }
          },
      :channel_pid => nil | pid(),
      :joins => %{
        binary() => %Slipstream.Socket.Join{
          :params => _,
          :rejoin_counter => _,
          :status => _,
          :topic => _
        }
      },
      :metadata => %{atom() => binary() | %{binary() => binary()}},
      :reconnect_counter => non_neg_integer(),
      :response_headers => _,
      :socket_pid => pid()
    }


but this value is unmatched.

________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```
</details>