### PR TITLE
fix connect closed when Mint.HTTP.stream/2 errors

### DIFF
--- a/lib/slipstream/connection/pipeline.ex
+++ b/lib/slipstream/connection/pipeline.ex
@@ -143,10 +143,10 @@ defmodule Slipstream.Connection.Pipeline do
         |> put_state(%State{p.state | conn: conn})
         |> decode_message()
 
-      {:error, conn, %Mint.TransportError{reason: :closed}} ->
+      {:error, conn, %Mint.TransportError{reason: :closed}, _} ->
         # coveralls-ignore-start
         p
-        |> put_state(put_in(p.state.conn, conn))
+        |> put_state(%{p.state | conn: conn})
         |> put_message(event(%Events.ChannelClosed{reason: :closed}))
 
       :unknown ->


### PR DESCRIPTION
hi. thanks for `slipstream`

I found one little error. I see the follow error message when connected is closed on server side. 
```
[error] GenServer #PID<0.1985.0> terminating
** (KeyError) key :conn not found in: %Slipstream.Connection.Pipeline{built_events: [], events: [], message: nil, raw_message: {:tcp_closed, #Port<0.20>}, return: nil, state: %Mint.HTTP1{buffer: "", host: "localhost", mode: :active, port: 4001, private: %{extensions: [], sec_websocket_key: "ZuXVw5LkilQrAEZNeTpx7Q=="}, proxy_headers: [], request: nil, requests: {[], []}, scheme_as_string: "http", socket: #Port<0.20>, state: :closed, streaming_request: %{body: nil, connection: [], content_length: nil, data_buffer: [], headers_buffer: [], method: nil, ref: #Reference<0.1182401425.3777495043.38195>, state: {:stream_request, :identity}, status: nil, transfer_encoding: [], version: nil}, transport: Mint.Core.Transport.TCP}}
    (slipstream 0.0.0) lib/slipstream/connection/pipeline.ex:414: Slipstream.Connection.Pipeline.handle_message/1
    (slipstream 0.0.0) lib/slipstream/connection/pipeline.ex:35: anonymous fn/1 in Slipstream.Connection.Pipeline.handle/2
    (slipstream 0.0.0) lib/slipstream/connection/telemetry.ex:29: anonymous fn/2 in Slipstream.Connection.Telemetry.span/2
    (telemetry 1.0.0) /....../deps/telemetry/src/telemetry.erl:293: :telemetry.span/3
    (slipstream 0.0.0) lib/slipstream/connection/telemetry.ex:25: Slipstream.Connection.Telemetry.span/2
    (stdlib 3.15.2) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.15.2) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.15.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:tcp_closed, #Port<0.20>}
```

