### PR TITLE
Update slipstream.ex

### DIFF
--- a/lib/slipstream.ex
+++ b/lib/slipstream.ex
@@ -43,7 +43,7 @@ defmodule Slipstream do
 
         @impl Slipstream
         def handle_continue(:start_ping, socket) do
-          timer = :timer.send_interval(self(), :request_metrics)
+          timer = :timer.send_interval(1000, self(), :request_metrics)
 
           {:noreply, assign(socket, :ping_timer, timer)}
         end


### PR DESCRIPTION
One more - `:timer.send_interval/2` requires the `time, message` and `:timer.send_interval/3` requires `time, pid, message` so I guessed you meant to add the time.