### PR TITLE
Fix typos

### DIFF
--- a/examples/token_refresh/README.md
+++ b/examples/token_refresh/README.md
@@ -54,7 +54,7 @@ end
 
 Now that we know when a token needs to be refreshed, let's add in some
 basic token logic to our client. First, we'll wrap `connect/2` with a
-custom function that retreives a token and modifies our config:
+custom function that retrieves a token and modifies our config:
 
 ```elixir
 defp make_new_token, do: "your_token_logic"

--- a/lib/slipstream/configuration.ex
+++ b/lib/slipstream/configuration.ex
@@ -177,7 +177,7 @@ defmodule Slipstream.Configuration do
       # coveralls-ignore-start
       {:port, bad_port} ->
         {:error,
-         "unparseable port value #{inspect(bad_port)}: please provide a positive-integer value"}
+         "unparsable port value #{inspect(bad_port)}: please provide a positive-integer value"}
 
       # coveralls-ignore-stop
 

--- a/lib/slipstream/connection/state.ex
+++ b/lib/slipstream/connection/state.ex
@@ -57,7 +57,7 @@ defmodule Slipstream.Connection.State do
   The `ref` passed between a client and phoenix server is a marker which
   can be used to link pushes to their replies. E.g. a heartbeat message from
   the client will include a ref which will match the associated heartbeat
-  reply from the server, when the heartbeat is sucessful.
+  reply from the server, when the heartbeat is successful.
 
   Refs are simply strings of incrementing integers.
   """

--- a/lib/slipstream/events/topic_leave_accepted.ex
+++ b/lib/slipstream/events/topic_leave_accepted.ex
@@ -3,7 +3,7 @@ defmodule Slipstream.Events.TopicLeaveAccepted do
 
   @type t :: %__MODULE__{}
 
-  # this is the direct reply to our request to LeaveTopic, and preceeds a
+  # this is the direct reply to our request to LeaveTopic, and precedes a
   # soon-to-arrive TopicLeft event
   # the difference is that this event is triggered by a phx_reply message
   # while the TopicLeft is triggered by phx_close

--- a/lib/slipstream/socket_test.ex
+++ b/lib/slipstream/socket_test.ex
@@ -462,7 +462,7 @@ defmodule Slipstream.SocketTest do
   end
 
   @doc """
-  Asserts that the client will request to push a messsage to the server
+  Asserts that the client will request to push a message to the server
 
   Note that `topic_expr`, `event_expr`, `params_expr`, and `ref_expr` are all
   pattern expressions. Prior bindings may be used with the `^` pin operator,

--- a/test/slipstream/integration_test.exs
+++ b/test/slipstream/integration_test.exs
@@ -150,7 +150,7 @@ defmodule Slipstream.IntegrationTest do
       assert_receive {@client, :left, ^topic}, @timeout
     end
 
-    test "trying to join a non-existant topic fails", c do
+    test "trying to join a non-existent topic fails", c do
       topic = "test:no function clause matching"
 
       :ok = join(c.pid, topic)

--- a/test/slipstream/socket_test_test.exs
+++ b/test/slipstream/socket_test_test.exs
@@ -171,7 +171,7 @@ defmodule Slipstream.SocketTestTest do
       refute_push ^topic, ^event, ^params
     end
 
-    test "we may capture when the client attepts to leave", c do
+    test "we may capture when the client attempts to leave", c do
       topic = c.topic
       GenServer.cast(@fixture, {:leave, topic})
       # N.B. bindings made with these macros can be used after the assert_ macro

--- a/test/support/pid_helpers.ex
+++ b/test/support/pid_helpers.ex
@@ -2,7 +2,7 @@ defmodule Slipstream.PidHelpers do
   @moduledoc """
   Helpers for dealing with pids
 
-  Most of the tests for slipstream involve processes sending eachother messages.
+  Most of the tests for slipstream involve processes sending each other messages.
   Some of these pids are sent over-the-wire as strings, so we need helper
   functions to serialize and deserialize them.
   """


### PR DESCRIPTION
Found via `codespell -S deps,_build,.git -L geting`