### PR TITLE
Allow configuring a serializer and support binary data

### DIFF
--- a/lib/slipstream.ex
+++ b/lib/slipstream.ex
@@ -1030,7 +1030,7 @@ defmodule Slipstream do
           socket :: Socket.t(),
           topic :: String.t(),
           event :: String.t(),
-          params :: json_serializable(),
+          params :: json_serializable() | {:binary, binary()},
           timeout :: timeout()
         ) :: {:ok, push_reference()} | {:error, reason :: term()}
   def push(

--- a/lib/slipstream/configuration.ex
+++ b/lib/slipstream/configuration.ex
@@ -34,6 +34,13 @@ defmodule Slipstream.Configuration do
       type: :atom,
       default: Jason
     ],
+    binary_parser: [
+      doc: """
+      A binary parser module which exports at least `encode!/1` and `decode!/2`.
+      """,
+      type: :atom,
+      default: Slipstream.Serializer.PhoenixSocketV2Serializer
+    ],
     reconnect_after_msec: [
       doc: """
       A list of times to reference for trying reconnection when
@@ -134,6 +141,7 @@ defmodule Slipstream.Configuration do
           heartbeat_interval_msec: non_neg_integer(),
           headers: [{String.t(), String.t()}],
           json_parser: module(),
+          binary_parser: module(),
           reconnect_after_msec: [non_neg_integer()],
           rejoin_after_msec: [non_neg_integer()]
         }

--- a/lib/slipstream/configuration.ex
+++ b/lib/slipstream/configuration.ex
@@ -34,6 +34,13 @@ defmodule Slipstream.Configuration do
       type: :atom,
       default: Slipstream.Serializer.PhoenixSocketV2Serializer
     ],
+    json_parser: [
+      doc: """
+      A JSON parser module which exports at least `encode!/1` and `decode!/1`.
+      """,
+      type: :atom,
+      default: Jason
+    ],
     reconnect_after_msec: [
       doc: """
       A list of times to reference for trying reconnection when
@@ -133,6 +140,7 @@ defmodule Slipstream.Configuration do
           uri: %URI{},
           heartbeat_interval_msec: non_neg_integer(),
           headers: [{String.t(), String.t()}],
+          json_parser: module(),
           serializer: module(),
           reconnect_after_msec: [non_neg_integer()],
           rejoin_after_msec: [non_neg_integer()]

--- a/lib/slipstream/configuration.ex
+++ b/lib/slipstream/configuration.ex
@@ -27,16 +27,9 @@ defmodule Slipstream.Configuration do
       type: {:list, {:custom, __MODULE__, :parse_pair_of_strings, []}},
       default: []
     ],
-    json_parser: [
+    serializer: [
       doc: """
-      A JSON parser module which exports at least `encode/1` and `decode/2`.
-      """,
-      type: :atom,
-      default: Jason
-    ],
-    binary_parser: [
-      doc: """
-      A binary parser module which exports at least `encode!/1` and `decode!/2`.
+      A serializer module which exports at least `encode!/1` and `decode!/2`.
       """,
       type: :atom,
       default: Slipstream.Serializer.PhoenixSocketV2Serializer
@@ -140,8 +133,7 @@ defmodule Slipstream.Configuration do
           uri: %URI{},
           heartbeat_interval_msec: non_neg_integer(),
           headers: [{String.t(), String.t()}],
-          json_parser: module(),
-          binary_parser: module(),
+          serializer: module(),
           reconnect_after_msec: [non_neg_integer()],
           rejoin_after_msec: [non_neg_integer()]
         }

--- a/lib/slipstream/connection/impl.ex
+++ b/lib/slipstream/connection/impl.ex
@@ -92,16 +92,18 @@ defmodule Slipstream.Connection.Impl do
 
   defp encode(%Message{} = message, state) do
     module = state.config.serializer
-    module.encode!(message)
+    module.encode!(message, json_parser: state.config.json_parser)
   end
 
-  # try decoding as json
   def decode_message({encoding, message}, state)
       when encoding in [:text, :binary] and is_binary(message) do
     module = state.config.serializer
 
     try do
-      module.decode!(message, opcode: encoding)
+      module.decode!(message,
+        opcode: encoding,
+        json_parser: state.config.json_parser
+      )
     rescue
       # coveralls-ignore-start
       _ in [Serializer.DecodeError] ->

--- a/lib/slipstream/connection/impl.ex
+++ b/lib/slipstream/connection/impl.ex
@@ -101,7 +101,7 @@ defmodule Slipstream.Connection.Impl do
     module = state.config.serializer
 
     try do
-      module.decode!(message)
+      module.decode!(message, opcode: encoding)
     rescue
       # coveralls-ignore-start
       _ in [Serializer.DecodeError] ->

--- a/lib/slipstream/serializer.ex
+++ b/lib/slipstream/serializer.ex
@@ -1,0 +1,15 @@
+defmodule Slipstream.Serializer do
+  @moduledoc """
+  A behaviour that serializes incoming and outgoing socket messages.
+  """
+
+  @doc """
+  Encodes `Slipstream.Message` structs to binary.
+  """
+  @callback encode!(Slipstream.Message.t(), options :: Keyword.t()) :: binary()
+
+  @doc """
+  Decodes binary into `Slipstream.Message` struct.
+  """
+  @callback decode!(binary, options :: Keyword.t()) :: Slipstream.Message.t()
+end

--- a/lib/slipstream/serializer/exceptions.ex
+++ b/lib/slipstream/serializer/exceptions.ex
@@ -1,0 +1,11 @@
+defmodule Slipstream.Serializer.EncodeError do
+  defexception [:message]
+
+  @type t :: %__MODULE__{message: String.t()}
+end
+
+defmodule Slipstream.Serializer.DecodeError do
+  defexception [:message]
+
+  @type t :: %__MODULE__{message: String.t()}
+end

--- a/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
+++ b/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
@@ -1,0 +1,94 @@
+defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
+  @behaviour Slipstream.Serializer
+
+  alias Slipstream.Message
+
+  @push 0
+  @reply 1
+
+  def encode!(%Message{payload: {:binary, data}} = message, _opts \\ []) do
+    join_ref = to_string(message.join_ref)
+    ref = to_string(message.ref)
+    join_ref_size = byte_size!(join_ref, :join_ref, 255)
+    ref_size = byte_size!(ref, :ref, 255)
+    topic_size = byte_size!(message.topic, :topic, 255)
+    event_size = byte_size!(message.event, :event, 255)
+
+    <<
+      @push::size(8),
+      join_ref_size::size(8),
+      ref_size::size(8),
+      topic_size::size(8),
+      event_size::size(8),
+      join_ref::binary-size(join_ref_size),
+      ref::binary-size(ref_size),
+      message.topic::binary-size(topic_size),
+      message.event::binary-size(event_size),
+      data::binary
+    >>
+  end
+
+  def decode!(binary, opts \\ [])
+
+  def decode!(
+        <<
+          @push::size(8),
+          join_ref_size::size(8),
+          topic_size::size(8),
+          event_size::size(8),
+          join_ref::binary-size(join_ref_size),
+          topic::binary-size(topic_size),
+          event::binary-size(event_size),
+          data::binary
+        >>,
+        _opts
+      ) do
+    %Message{
+      topic: topic,
+      event: event,
+      payload: {:binary, data},
+      ref: nil,
+      join_ref: join_ref
+    }
+  end
+
+  def decode!(
+        <<
+          @reply::size(8),
+          join_ref_size::size(8),
+          ref_size::size(8),
+          topic_size::size(8),
+          status_size::size(8),
+          join_ref::binary-size(join_ref_size),
+          ref::binary-size(ref_size),
+          topic::binary-size(topic_size),
+          status::binary-size(status_size),
+          data::binary
+        >>,
+        _opts
+      ) do
+    %Message{
+      topic: topic,
+      event: "phx_reply",
+      payload: %{"response" => {:binary, data}, "status" => status},
+      ref: ref,
+      join_ref: join_ref
+    }
+  end
+
+  defp byte_size!(bin, kind, max) do
+    case byte_size(bin) do
+      size when size <= max ->
+        size
+
+      oversized ->
+        raise ArgumentError, """
+        unable to convert #{kind} to binary.
+
+            #{inspect(bin)}
+
+        must be less than or equal to #{max} bytes, but is #{oversized} bytes.
+        """
+    end
+  end
+end

--- a/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
+++ b/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
@@ -55,10 +55,20 @@ defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
       ]
       |> Jason.encode!(opts)
     rescue
+      # coveralls-ignore-start
       exception in [Jason.EncodeError] ->
         reraise(
           Serializer.EncodeError,
           [message: exception.message],
+          __STACKTRACE__
+        )
+
+      # coveralls-ignore-stop
+
+      exception in [Protocol.UndefinedError] ->
+        reraise(
+          Serializer.EncodeError,
+          [message: inspect(exception)],
           __STACKTRACE__
         )
     end
@@ -71,12 +81,15 @@ defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
         :binary -> decode_binary!(binary)
       end
     rescue
+      # coveralls-ignore-start
       exception in [Jason.DecodeError, KeyError] ->
         reraise(
           Serializer.DecodeError,
           [message: exception.message],
           __STACKTRACE__
         )
+
+      # coveralls-ignore-stop
 
       exception in [FunctionClauseError] ->
         reraise(

--- a/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
+++ b/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
@@ -1,4 +1,8 @@
 defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
+  @moduledoc """
+  A client-side implementation that corresponds to the server-side Phoenix.Socket.V2.JSONSerializer.
+  """
+
   @behaviour Slipstream.Serializer
 
   alias Slipstream.Message

--- a/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
+++ b/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
@@ -2,30 +2,62 @@ defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
   @behaviour Slipstream.Serializer
 
   alias Slipstream.Message
+  alias Slipstream.Serializer
 
   @push 0
   @reply 1
 
-  def encode!(%Message{payload: {:binary, data}} = message, _opts \\ []) do
-    join_ref = to_string(message.join_ref)
-    ref = to_string(message.ref)
-    join_ref_size = byte_size!(join_ref, :join_ref, 255)
-    ref_size = byte_size!(ref, :ref, 255)
-    topic_size = byte_size!(message.topic, :topic, 255)
-    event_size = byte_size!(message.event, :event, 255)
+  def encode!(binary, opts \\ [])
 
-    <<
-      @push::size(8),
-      join_ref_size::size(8),
-      ref_size::size(8),
-      topic_size::size(8),
-      event_size::size(8),
-      join_ref::binary-size(join_ref_size),
-      ref::binary-size(ref_size),
-      message.topic::binary-size(topic_size),
-      message.event::binary-size(event_size),
-      data::binary
-    >>
+  def encode!(%Message{payload: {:binary, data}} = message, _opts) do
+    try do
+      join_ref = to_string(message.join_ref)
+      ref = to_string(message.ref)
+      join_ref_size = byte_size!(join_ref, :join_ref, 255)
+      ref_size = byte_size!(ref, :ref, 255)
+      topic_size = byte_size!(message.topic, :topic, 255)
+      event_size = byte_size!(message.event, :event, 255)
+
+      <<
+        @push::size(8),
+        join_ref_size::size(8),
+        ref_size::size(8),
+        topic_size::size(8),
+        event_size::size(8),
+        join_ref::binary-size(join_ref_size),
+        ref::binary-size(ref_size),
+        message.topic::binary-size(topic_size),
+        message.event::binary-size(event_size),
+        data::binary
+      >>
+    rescue
+      exception in [ArgumentError] ->
+        reraise(
+          Serializer.EncodeError,
+          [message: exception.message],
+          __STACKTRACE__
+        )
+    end
+  end
+
+  def encode!(%Message{} = message, opts) do
+    try do
+      [
+        message.join_ref,
+        message.ref,
+        message.topic,
+        message.event,
+        message.payload
+      ]
+      |> Jason.encode!(opts)
+    rescue
+      exception in [Jason.EncodeError] ->
+        reraise(
+          Serializer.EncodeError,
+          [message: exception.message],
+          __STACKTRACE__
+        )
+    end
   end
 
   def decode!(binary, opts \\ [])
@@ -74,6 +106,35 @@ defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
       ref: ref,
       join_ref: join_ref
     }
+  end
+
+  def decode!(binary, opts) do
+    try do
+      case Jason.decode!(binary, opts) do
+        [join_ref, ref, topic, event, payload | _] ->
+          %Message{
+            join_ref: join_ref,
+            ref: ref,
+            topic: topic,
+            event: event,
+            payload: payload
+          }
+
+        # coveralls-ignore-start
+        # this may occur if the remote websocket server does not support the v2
+        # transport packets
+        decoded_json when is_map(decoded_json) ->
+          Message.from_map!(decoded_json)
+          # coveralls-ignore-stop
+      end
+    rescue
+      exception in [Jason.DecodeError, KeyError] ->
+        reraise(
+          Serializer.DecodeError,
+          [message: exception.message],
+          __STACKTRACE__
+        )
+    end
   end
 
   defp byte_size!(bin, kind, max) do

--- a/test/slipstream/serializer/phoenix_socket_v2_serializer_test.exs
+++ b/test/slipstream/serializer/phoenix_socket_v2_serializer_test.exs
@@ -1,0 +1,38 @@
+defmodule Slipstream.Serializer.PhoenixSocketV2SerializerTest do
+  use ExUnit.Case
+
+  @moduledoc """
+  Tests cover the exception handlings of PhoenixSocketV2Serializer.
+  """
+
+  import Slipstream.Serializer.PhoenixSocketV2Serializer,
+    only: [encode!: 1, decode!: 2]
+
+  alias Slipstream.Message
+
+  describe "encode!/1 raise Slipstream.Serializer.EncodeError" do
+    test "when binary payload, topic size is greater than 255 bytes" do
+      assert_raise(Slipstream.Serializer.EncodeError, fn ->
+        encode!(%Message{
+          payload: {:binary, _data = ""},
+          topic: String.duplicate("a", 256)
+        })
+      end)
+    end
+
+    test "when payload won't be encoded" do
+      assert_raise(Slipstream.Serializer.EncodeError, fn ->
+        # tuple cannot be encoded to JSON
+        encode!(%Message{payload: {"a"}})
+      end)
+    end
+  end
+
+  describe "decode!/1 raise Slipstream.Serializer.DecodeError" do
+    test "binary does't match function arugment pattern" do
+      assert_raise(Slipstream.Serializer.DecodeError, fn ->
+        decode!(<<>>, opcode: :binary)
+      end)
+    end
+  end
+end

--- a/test/slipstream/serializer/phoenix_socket_v2_serializer_test.exs
+++ b/test/slipstream/serializer/phoenix_socket_v2_serializer_test.exs
@@ -6,24 +6,27 @@ defmodule Slipstream.Serializer.PhoenixSocketV2SerializerTest do
   """
 
   import Slipstream.Serializer.PhoenixSocketV2Serializer,
-    only: [encode!: 1, decode!: 2]
+    only: [encode!: 2, decode!: 2]
 
   alias Slipstream.Message
 
-  describe "encode!/1 raise Slipstream.Serializer.EncodeError" do
+  describe "encode!/2 raise Slipstream.Serializer.EncodeError" do
     test "when binary payload, topic size is greater than 255 bytes" do
       assert_raise(Slipstream.Serializer.EncodeError, fn ->
-        encode!(%Message{
-          payload: {:binary, _data = ""},
-          topic: String.duplicate("a", 256)
-        })
+        encode!(
+          %Message{
+            payload: {:binary, _data = ""},
+            topic: String.duplicate("a", 256)
+          },
+          json_parser: Jason
+        )
       end)
     end
 
     test "when payload won't be encoded" do
       assert_raise(Slipstream.Serializer.EncodeError, fn ->
         # tuple cannot be encoded to JSON
-        encode!(%Message{payload: {"a"}})
+        encode!(%Message{payload: {"a"}}, json_parser: Jason)
       end)
     end
   end
@@ -31,7 +34,7 @@ defmodule Slipstream.Serializer.PhoenixSocketV2SerializerTest do
   describe "decode!/1 raise Slipstream.Serializer.DecodeError" do
     test "binary does't match function arugment pattern" do
       assert_raise(Slipstream.Serializer.DecodeError, fn ->
-        decode!(<<>>, opcode: :binary)
+        decode!(<<>>, opcode: :binary, json_parser: Jason)
       end)
     end
   end

--- a/test/slipstream/synchronicity_test.exs
+++ b/test/slipstream/synchronicity_test.exs
@@ -121,6 +121,23 @@ defmodule Slipstream.SynchronicityTest do
                await_message!(^topic, "foo", %{})
     end
 
+    test "a binary message may be received synchronously", c do
+      topic = c.topic
+      event = "push to me"
+      params = {:binary, <<0, 1>>}
+      expected_payload = {:binary, <<2, 3>>}
+
+      push!(c.socket, topic, event, params)
+
+      assert {:ok, ^topic, "foo", ^expected_payload} =
+               await_message(^topic, "foo", ^expected_payload)
+
+      push!(c.socket, topic, event, params)
+
+      assert {:ok, ^topic, "foo", ^expected_payload} =
+               await_message(^topic, "foo", ^expected_payload)
+    end
+
     test "a reply can be received synchronously", c do
       topic = c.topic
       event = "ping"
@@ -132,6 +149,23 @@ defmodule Slipstream.SynchronicityTest do
                |> await_reply()
 
       assert {:ok, %{"pong" => "pong"}} =
+               c.socket
+               |> push!(topic, event, params)
+               |> await_reply!()
+    end
+
+    test "a binary reply can be received synchronously", c do
+      topic = c.topic
+      event = "ping"
+      params = {:binary, <<0, 1>>}
+      expected_payload = {:binary, <<2, 3>>}
+
+      assert {:ok, ^expected_payload} =
+               c.socket
+               |> push!(topic, event, params)
+               |> await_reply()
+
+      assert {:ok, ^expected_payload} =
                c.socket
                |> push!(topic, event, params)
                |> await_reply!()

--- a/test/support/lib/slipstream_web/channels/test_channel.ex
+++ b/test/support/lib/slipstream_web/channels/test_channel.ex
@@ -31,12 +31,22 @@ defmodule SlipstreamWeb.TestChannel do
   end
 
   # responds to the request
+  def handle_in("ping", {:binary, _}, socket) do
+    {:reply, {:ok, {:binary, <<2, 3>>}}, socket}
+  end
+
   def handle_in("ping", _params, socket) do
     {:reply, {:ok, %{"pong" => "pong"}}, socket}
   end
 
   # responds, but not with a reply
   # just an async send
+  def handle_in("push to me", {:binary, _}, socket) do
+    push(socket, "foo", {:binary, <<2, 3>>})
+
+    {:noreply, socket}
+  end
+
   def handle_in("push to me", _params, socket) do
     push(socket, "foo", %{"bar" => "baz"})
 


### PR DESCRIPTION
This PR tries to implement handling binary data feature, relates to #28 and #53.

This may include implementation and testing omissions due to a lack of understanding of the Slipstream overview.

Roughly, I first prepare the Serializer `behaviour` as `Slipstream.Serializer`, then implement client side silializer which corresponding to [Phoenix V2 JSON serializer]( https://github.com/phoenixframework/phoenix/blob/main/lib/phoenix/socket/serializers/v2_json_serializer).

I followed the TDD, first added tests to synchronicity_test.exs and then implemented to satisfy them.

This PR is intended to be the base of implementation and should be modified to fit this project.