### PR TITLE
Deserialize binary broadcast messages

### DIFF
--- a/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
+++ b/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
@@ -10,6 +10,7 @@ defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
 
   @push 0
   @reply 1
+  @broadcast 2
 
   def encode!(%Message{payload: {:binary, data}} = message, _opts) do
     try do
@@ -136,6 +137,23 @@ defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
       payload: %{"response" => {:binary, data}, "status" => status},
       ref: ref,
       join_ref: join_ref
+    }
+  end
+
+  defp decode_binary!(<<
+         @broadcast::size(8),
+         topic_size::size(8),
+         event_size::size(8),
+         topic::binary-size(topic_size),
+         event::binary-size(event_size),
+         data::binary
+       >>) do
+    %Message{
+      topic: topic,
+      event: event,
+      payload: {:binary, data},
+      ref: nil,
+      join_ref: nil
     }
   end
 

--- a/test/slipstream/integration_test.exs
+++ b/test/slipstream/integration_test.exs
@@ -119,6 +119,32 @@ defmodule Slipstream.IntegrationTest do
                      @timeout
     end
 
+    test "a regular broadcast may be received from the server", c do
+      topic = c.good_topic
+
+      :ok = join(c.pid, topic)
+      assert_receive {@client, :joined, ^topic, _reply}, @timeout
+
+      :ok = GenServer.cast(c.pid, {:push, topic, "broadcast", %{}})
+
+      assert_receive {@client, :received_message, ^topic, "broadcast event",
+                      %{"hello" => "everyone!"}},
+                     @timeout
+    end
+
+    test "a binary broadcast may be received from the server", c do
+      topic = c.good_topic
+
+      :ok = join(c.pid, topic)
+      assert_receive {@client, :joined, ^topic, _reply}, @timeout
+
+      :ok = GenServer.cast(c.pid, {:push, topic, "binary broadcast", %{}})
+
+      assert_receive {@client, :received_message, ^topic, "broadcast event",
+                      {:binary, "🏴‍☠️"}},
+                     @timeout
+    end
+
     test "a connection may be disconnected", c do
       topic = c.good_topic
 

--- a/test/support/lib/slipstream_web/channels/test_channel.ex
+++ b/test/support/lib/slipstream_web/channels/test_channel.ex
@@ -65,6 +65,28 @@ defmodule SlipstreamWeb.TestChannel do
     raise "oooooooohnnnnnnnnnnnnnoooooooooooooooooooooooooooooo"
   end
 
+  def handle_in("broadcast", _params, socket) do
+    :ok =
+      SlipstreamWeb.Endpoint.broadcast!(
+        socket.assigns.topic,
+        "broadcast event",
+        %{hello: "everyone!"}
+      )
+
+    {:noreply, socket}
+  end
+
+  def handle_in("binary broadcast", _params, socket) do
+    :ok =
+      SlipstreamWeb.Endpoint.broadcast!(
+        socket.assigns.topic,
+        "broadcast event",
+        {:binary, "🏴‍☠️"}
+      )
+
+    {:noreply, socket}
+  end
+
   def handle_in("stop", _params, socket) do
     {:stop, :normal, socket}
   end


### PR DESCRIPTION
Fixes #17

It looks like the (de)serializer module was just missing the broadcast deserialization clause.