### PR TITLE
support refreshing connection config during `reconnect`

### DIFF
--- a/lib/slipstream.ex
+++ b/lib/slipstream.ex
@@ -226,7 +226,7 @@ defmodule Slipstream do
       end
   """
 
-  alias Slipstream.{Commands, Events, Socket, TelemetryHelper}
+  alias Slipstream.{Commands, Events, Socket, TelemetryHelper, Configuration}
   import Slipstream.CommandRouter, only: [route_command: 1]
   import Slipstream.Signatures, only: [event: 1, command: 1]
 
@@ -694,6 +694,28 @@ defmodule Slipstream do
               | {:stop, stop_reason :: term(), new_socket}
             when new_socket: Socket.t()
 
+  @doc """
+  Invoked when a socket reconnection is triggered via `reconnect/1`.
+
+  This callback allows for connection config properties to be updated,
+  useful for cases where authentication tokens or headers might have
+  expired.
+
+  ## Examples
+
+      @impl Slipstream
+      def refresh_connection_config(socket, config) do
+        config
+        |> Map.put(:headers, generate_headers(socket))
+        |> Map.put(:url, update_uri(socket))
+      end
+  """
+  @doc since: "1.1.2"
+  @callback refresh_connection_config(
+              socket :: Socket.t(),
+              config :: Configuration.t()
+            ) :: Configuration.t()
+
   @optional_callbacks init: 1,
                       handle_info: 2,
                       handle_cast: 2,
@@ -706,7 +728,8 @@ defmodule Slipstream do
                       handle_message: 4,
                       handle_reply: 3,
                       handle_topic_close: 3,
-                      handle_leave: 2
+                      handle_leave: 2,
+                      refresh_connection_config: 2
 
   # --- core functionality
 
@@ -1508,8 +1531,6 @@ defmodule Slipstream do
         |> Supervisor.child_spec(unquote(Macro.escape(opts)))
       end
 
-      defoverridable child_spec: 1
-
       require Slipstream.Signatures
 
       import Slipstream
@@ -1532,6 +1553,9 @@ defmodule Slipstream do
         Slipstream.Callback.dispatch(__MODULE__, event, socket)
       end
 
+      @impl Slipstream
+      def refresh_connection_config(socket, config), do: config
+
       # this matches on time-delay commands like those emitted from
       # reconnect/1 and rejoin/3
       def handle_info(
@@ -1540,7 +1564,11 @@ defmodule Slipstream do
             ),
             socket
           ) do
-        socket = TelemetryHelper.begin_connect(socket, cmd.config)
+        config = refresh_connection_config(socket, cmd.config)
+
+        socket = TelemetryHelper.begin_connect(socket, config)
+
+        cmd = %{cmd | config: config}
 
         _ = Slipstream.CommandRouter.route_command(cmd)
 
@@ -1559,6 +1587,8 @@ defmodule Slipstream do
 
         {:noreply, socket}
       end
+
+      defoverridable child_spec: 1, refresh_connection_config: 2
     end
   end
 end


### PR DESCRIPTION
This adds a callback to update the connection config when `reconnect` is called.

Although there is an example on how to capture `403` connection errors and fresh a uri token, this means you don't get to use the `reconnect_after_msec` logic built into `reconnect`.

