### PR TITLE
Fix Elixir 1.17 type error

### DIFF
--- a/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
+++ b/lib/slipstream/serializer/phoenix_socket_v2_serializer.ex
@@ -65,7 +65,7 @@ defmodule Slipstream.Serializer.PhoenixSocketV2Serializer do
       maybe_json_parser_exception ->
         reraise(
           Serializer.EncodeError,
-          [message: maybe_json_parser_exception.message],
+          [message: Exception.message(maybe_json_parser_exception)],
           __STACKTRACE__
         )
 


### PR DESCRIPTION
This fixes this error message:

```
    warning: unknown key .message in expression:

        maybe_json_parser_exception.message

    where "maybe_json_parser_exception" was given the type:

        # type: %{..., __exception__: true, __struct__: atom()}
        # from: lib/slipstream/serializer/phoenix_socket_v2_serializer.ex:65
        rescue maybe_json_parser_exception ->

    hint: when you rescue without specifying exception names, the variable is assigned a type of a struct but all of its fields are unknown. If you are trying to access an exception's :message key, either specify the exception names or use `Exception.message/1`.

    typing violation found at:
    │
 68 │           [message: maybe_json_parser_exception.message],
    │                                                 ~~~~~~~
    │
    └─ lib/slipstream/serializer/phoenix_socket_v2_serializer.ex:68:49: Slipstream.Serializer.PhoenixSocketV2Serializer.encode!/2
```
