### PR TITLE
Add support for a binary serializer

### DIFF
--- a/lib/slipstream/connection/impl.ex
+++ b/lib/slipstream/connection/impl.ex
@@ -77,7 +77,13 @@ defmodule Slipstream.Connection.Impl do
   end
 
   def push_message(message, state) do
-    push_message({:text, encode(message, state)}, state)
+    message =
+      case encode(message, state) do
+        {:binary, message} -> {:binary, message}
+        message when is_binary(message) -> {:text, message}
+      end
+
+    push_message(message, state)
   end
 
   # coveralls-ignore-start

--- a/lib/slipstream/serializer.ex
+++ b/lib/slipstream/serializer.ex
@@ -5,8 +5,13 @@ defmodule Slipstream.Serializer do
 
   @doc """
   Encodes `Slipstream.Message` structs to binary.
+
+  Should return either a binary (string) when using a text based protocol
+  or `{:binary, binary}` for cases where a binary protocol is used over
+  the wire (such as MessagePack).
   """
-  @callback encode!(Slipstream.Message.t(), options :: Keyword.t()) :: binary()
+  @callback encode!(Slipstream.Message.t(), options :: Keyword.t()) ::
+              binary() | {:binary, binary()}
 
   @doc """
   Decodes binary into `Slipstream.Message` struct.

--- a/test/fixtures/good_example.ex
+++ b/test/fixtures/good_example.ex
@@ -5,16 +5,17 @@ defmodule Slipstream.GoodExample do
 
   use Slipstream, restart: :transient
 
-  @config Application.compile_env!(:slipstream, __MODULE__)
-
   def start_link(opts) do
     Slipstream.start_link(__MODULE__, opts)
   end
 
   @impl Slipstream
-  def init(test_proc) do
+  def init(opts) do
+    {test_proc, opts} = Keyword.pop!(opts, :pid)
+    opts = Keyword.put_new(opts, :uri, "ws://localhost:4001/socket/websocket")
+
     socket =
-      @config
+      opts
       |> connect!()
       |> assign(:test_proc, test_proc)
 

--- a/test/slipstream/client_telemetry_test.exs
+++ b/test/slipstream/client_telemetry_test.exs
@@ -45,7 +45,7 @@ defmodule Slipstream.ClientTelemetryTest do
     end
 
     test "when we connect and disconnect, we get expected telemetry" do
-      start_supervised!({@client, self()})
+      start_supervised!({@client, pid: self()})
       assert_receive {@client, :connected}
 
       assert_receive {:telemetry, [:slipstream, :client, :connect, :start],
@@ -66,7 +66,7 @@ defmodule Slipstream.ClientTelemetryTest do
 
     test "when we join a channel, we get expected telemetry" do
       topic = "test:good"
-      pid = start_supervised!({@client, self()})
+      pid = start_supervised!({@client, pid: self()})
       assert_receive {@client, :connected}
       join(pid, topic)
       assert_receive {@client, :joined, ^topic, %{}}
@@ -88,7 +88,7 @@ defmodule Slipstream.ClientTelemetryTest do
 
     test "when we receive a message, we get expected telemetry" do
       topic = "test:good"
-      pid = start_supervised!({@client, self()})
+      pid = start_supervised!({@client, pid: self()})
       assert_receive {@client, :connected}
       join(pid, topic)
       assert_receive {@client, :joined, ^topic, %{}}

--- a/test/slipstream/connection_telemetry_test.exs
+++ b/test/slipstream/connection_telemetry_test.exs
@@ -45,7 +45,7 @@ defmodule Slipstream.ConnectionTelemetryTest do
     end
 
     test "when we connect and disconnect, we get expected telemetry" do
-      start_supervised!({@client, self()})
+      start_supervised!({@client, [pid: self()]})
       assert_receive {@client, :connected}
 
       assert_receive {:telemetry, [:slipstream, :connection, :connect, :start],
@@ -68,7 +68,7 @@ defmodule Slipstream.ConnectionTelemetryTest do
     end
 
     test "when we successfully connect, we handle mint messages" do
-      start_supervised!({@client, self()})
+      start_supervised!({@client, pid: self()})
       assert_receive {@client, :connected}
 
       assert_receive {:telemetry, [:slipstream, :connection, :connect, :start],

--- a/test/slipstream/connection_telemetry_test.exs
+++ b/test/slipstream/connection_telemetry_test.exs
@@ -45,7 +45,7 @@ defmodule Slipstream.ConnectionTelemetryTest do
     end
 
     test "when we connect and disconnect, we get expected telemetry" do
-      start_supervised!({@client, [pid: self()]})
+      start_supervised!({@client, pid: self()})
       assert_receive {@client, :connected}
 
       assert_receive {:telemetry, [:slipstream, :connection, :connect, :start],

--- a/test/support/lib/slipstream_web/endpoint.ex
+++ b/test/support/lib/slipstream_web/endpoint.ex
@@ -20,6 +20,11 @@ defmodule SlipstreamWeb.Endpoint do
     longpoll: false
   )
 
+  socket("/socket/etf", SlipstreamWeb.UserSocket,
+    websocket: [serializer: [{SlipstreamWeb.EtfSerializer, "~> 2.0.0"}]],
+    longpoll: false
+  )
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phx.digest

--- a/test/support/lib/slipstream_web/etf_serializer.ex
+++ b/test/support/lib/slipstream_web/etf_serializer.ex
@@ -1,0 +1,44 @@
+defmodule SlipstreamWeb.EtfSerializer do
+  @moduledoc false
+  @behaviour Phoenix.Socket.Serializer
+
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
+
+  @impl true
+  def fastlane!(%Broadcast{} = msg) do
+    data = :erlang.term_to_binary([nil, nil, msg.topic, msg.event, msg.payload])
+    {:socket_push, :binary, data}
+  end
+
+  @impl true
+  def encode!(%Reply{} = reply) do
+    data = [
+      reply.join_ref,
+      reply.ref,
+      reply.topic,
+      "phx_reply",
+      %{status: reply.status, response: reply.payload}
+    ]
+
+    {:socket_push, :binary, :erlang.term_to_binary(data)}
+  end
+
+  def encode!(%Message{} = msg) do
+    data = [msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload]
+    {:socket_push, :binary, :erlang.term_to_binary(data)}
+  end
+
+  @impl true
+  def decode!(raw_message, _opts) do
+    [join_ref, ref, topic, event, payload | _] =
+      :erlang.binary_to_term(raw_message)
+
+    %Message{
+      topic: topic,
+      event: event,
+      payload: payload,
+      ref: ref,
+      join_ref: join_ref
+    }
+  end
+end


### PR DESCRIPTION
In some cases, when using Phoenix channels, it is possible to use a binary serializer. The library already has support for binary messages, but this is slightly different. With a binary serializer, all messages can be sent in a binary format, not just individual payloads. This commit changes the contract for the serializer to allow returning a binary as before, or the tuple `{:binary, binary}`

In the integration tests, an example binary encoder that uses `term_to_binary/1` and `binary_to_term/1` is used. The integration tests are run both against the existing text based serializer, and the reference binary serializer. The `GoodExample` has been modified to take a set of options instead of reading them from the config, although a fallback is used to minimize the number of tests updated.