### PR TITLE
Fix CaseClauseError on WebSocket close frame

### DIFF
--- a/lib/slipstream/connection/pipeline.ex
+++ b/lib/slipstream/connection/pipeline.ex
@@ -158,6 +158,15 @@ defmodule Slipstream.Connection.Pipeline do
         |> put_state(%{p.state | conn: conn})
         |> put_message(event(%Events.ChannelClosed{reason: reason}))
 
+      {:error, conn, reason, _responses} ->
+        Logger.error(
+          "Closing connection because of error: #{inspect(reason)}"
+        )
+
+        p
+        |> put_state(%{p.state | conn: conn})
+        |> put_message(event(%Events.ChannelClosed{reason: reason}))
+
       :unknown ->
         Logger.error("""
         unknown message #{inspect(p.raw_message)} \


### PR DESCRIPTION
Mint.WebSocket.stream/2 can return {:error, conn, %Mint.HTTPError{}, _} when the server sends a WebSocket close frame after the HTTP/1 request is already complete. The existing case clauses only matched Mint.TransportError, causing a CaseClauseError that crashes the connection process.

Add a catch-all {:error, conn, reason, _} clause that treats any unhandled error as a graceful ChannelClosed event, allowing the client to handle it via handle_disconnect/2.